### PR TITLE
remove lint-staged & update husky

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,1 @@
 dist/
-types/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 <a href="https://npmjs.com/package/berial"><img src="https://img.shields.io/npm/dt/berial.svg" alt="npm-d"></a>
 </p>
 
-
 ### Feature
 
 - shadow dom

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "rollup -c",
     "check": "run-p fmt-check lint",
     "dev": "rollup -c --watch",
-    "fix": "eslint --fix **/*.ts",
+    "fix": "run-s \"lint -- --fix\"",
     "fmt": "run-s \"fmt-check -- --write\"",
     "fmt-check": "prettier --check **/*.{md,json,ts}",
     "lint": "eslint **/*.ts",
@@ -37,9 +37,8 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.20.5",
-    "husky": "^3.0.9",
+    "husky": "^4.2.5",
     "jest": "^24.1.0",
-    "lint-staged": "^10.2.11",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.5",
     "rollup": "^2.23.0",
@@ -48,14 +47,9 @@
     "tslib": "^2.0.0",
     "typescript": "^3.9.7"
   },
-  "lint-staged": {
-    "*.ts?(x)": [
-      "npm run fix"
-    ]
-  },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run type && lint-staged"
+      "pre-commit": "run-p fmt fix; git add ."
     }
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -202,7 +202,7 @@ window.addEventListener('hashchange', urlReroute)
 window.addEventListener('popstate', urlReroute)
 const originalAddEventListener = window.addEventListener
 const originalRemoveEventListener = window.removeEventListener
-window.addEventListener = function(name: any, fn: any, ...args: any) {
+window.addEventListener = function (name: any, fn: any, ...args: any) {
   if (
     routingEventsListeningTo.indexOf(name) >= 0 &&
     !capturedEvents[name].some((l: any) => l == fn)
@@ -213,7 +213,7 @@ window.addEventListener = function(name: any, fn: any, ...args: any) {
   // @ts-ignore
   return originalAddEventListener.apply(this, args)
 }
-window.removeEventListener = function(name: any, fn: any, ...args: any) {
+window.removeEventListener = function (name: any, fn: any, ...args: any) {
   if (routingEventsListeningTo.indexOf(name) >= 0) {
     capturedEvents[name] = capturedEvents[name].filter((l: any) => l !== fn)
     return
@@ -223,7 +223,7 @@ window.removeEventListener = function(name: any, fn: any, ...args: any) {
 }
 
 function patchedUpdateState(updateState: any, ...args: any) {
-  return function() {
+  return function () {
     const urlBefore = window.location.href
     // @ts-ignore
     updateState.apply(this, args)


### PR DESCRIPTION
我们不需要 Lint Staged:
- 项目文件很少, 全量检查造成的速度损失小于引入 Lint Staged
- 整合 CI 和 Lint Staged 中的 scripts 比较麻烦

@h-a-n-a 