### PR TITLE
fix: 解决 React 等将事件处理统一放在 Document 上, 导致 shadowDom 下事件不触发的问题

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,7 @@
 import type { App, Lifecycles } from './types'
 import { importHtml } from './html-loader'
 import { lifecycleCheck } from './util'
+import { bridgeEvent } from './bridgeEvent'
 
 export enum Status {
   NOT_LOADED = 'NOT_LOADED',
@@ -121,6 +122,7 @@ async function runLoad(app: App, store: any): Promise<any> {
       for (const k of styleNodes) {
         host.shadowRoot!.insertBefore(k, host.shadowRoot!.firstChild)
       }
+      bridgeEvent(host.shadowRoot)
     } else {
       lifecycle = (await app.entry(app)) as any
       lifecycleCheck(lifecycle)

--- a/src/app.ts
+++ b/src/app.ts
@@ -122,11 +122,11 @@ async function runLoad(app: App, store: any): Promise<any> {
       for (const k of styleNodes) {
         host.shadowRoot!.insertBefore(k, host.shadowRoot!.firstChild)
       }
-      bridgeEvent(host.shadowRoot)
     } else {
       lifecycle = (await app.entry(app)) as any
       lifecycleCheck(lifecycle)
     }
+    bridgeEvent(host.shadowRoot)
     app.status = Status.NOT_BOOTSTRAPPED
     app.bootstrap = compose(lifecycle.bootstrap)
     app.mount = compose(lifecycle.mount)

--- a/src/bridgeEvent.ts
+++ b/src/bridgeEvent.ts
@@ -1,0 +1,95 @@
+export function bridgeEvent(shadowRoot: ShadowRoot) {
+  const define = Object.defineProperty
+  const fromNode = shadowRoot,
+    toNode = shadowRoot.host
+  BRIDGE_EVENT_NAMES.map((eventName) => {
+    fromNode.addEventListener(eventName, (fromEvent) => {
+      fromEvent.stopPropagation()
+      const Event = fromEvent.constructor
+      // @ts-ignore
+      const toEvent = new Event(eventName, {
+        ...fromEvent,
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      })
+      const {
+        path = [],
+        target = path[0],
+        srcElement = path[0],
+        toElement = path[0],
+        preventDefault
+      } = fromEvent as any
+      define(toEvent, 'path', { get: () => path })
+      define(toEvent, 'target', { get: () => target })
+      define(toEvent, 'srcElement', { get: () => srcElement })
+      define(toEvent, 'toElement', { get: () => toElement })
+      define(toEvent, 'preventDefault', {
+        value: () => {
+          preventDefault.call(fromEvent)
+          return preventDefault.call(toEvent)
+        }
+      })
+      toNode.dispatchEvent(toEvent)
+    })
+  })
+}
+
+export const BRIDGE_EVENT_NAMES = [
+  'abort',
+  'animationcancel',
+  'animationend',
+  'animationiteration',
+  'auxclick',
+  'blur',
+  'change',
+  'click',
+  'close',
+  'contextmenu',
+  'doubleclick',
+  'error',
+  'focus',
+  'gotpointercapture',
+  'input',
+  'keydown',
+  'keypress',
+  'keyup',
+  'load',
+  'loadend',
+  'loadstart',
+  'lostpointercapture',
+  'mousedown',
+  'mousemove',
+  'mouseout',
+  'mouseover',
+  'mouseup',
+  'pointercancel',
+  'pointerdown',
+  'pointerenter',
+  'pointerleave',
+  'pointermove',
+  'pointerout',
+  'pointerover',
+  'pointerup',
+  'reset',
+  'resize',
+  'scroll',
+  'select',
+  'selectionchange',
+  'selectstart',
+  'submit',
+  'touchcancel',
+  'touchmove',
+  'touchstart',
+  'transitioncancel',
+  'transitionend',
+  'drag',
+  'dragend',
+  'dragenter',
+  'dragexit',
+  'dragleave',
+  'dragover',
+  'dragstart',
+  'drop',
+  'focusout'
+]


### PR DESCRIPTION
主要是解决这个问题：https://github.com/facebook/react/issues/9242

在 ShadowDom 下渲染 React 应用的时候，会发现 React 的所有事件都无法触发。
这个是由于 ShadowDom 里触发的事件，在外层拿到 event.target 的时候，只会拿到 host，所以导致了 react 的事件调度出现了问题。