### PR TITLE
fix: get shadowRoot before render

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -98,7 +98,7 @@ async function runLoad(app: App): Promise<any> {
   app.loaded = Promise.resolve().then(async () => {
     app.status = Status.LOADING
     let mixinLife = mapMixin()
-    app.host = loadShadowDOM(app)
+    app.host = await loadShadowDOM(app)
     const { lifecycle: selfLife, bodyNode, styleNodes } = await importHtml(app)
     lifecycleCheck(selfLife)
     app.host?.appendChild(bodyNode.content.cloneNode(true))
@@ -114,22 +114,22 @@ async function runLoad(app: App): Promise<any> {
   return app.loaded
 }
 
-function loadShadowDOM(app: App): any {
-  let host = null
-  class Berial extends HTMLElement {
-    static get tag(): string {
-      return app.name
+function loadShadowDOM(app: App): Promise<DocumentFragment> {
+  return new Promise((resolve, reject) => {
+    class Berial extends HTMLElement {
+      static get tag(): string {
+        return app.name
+      }
+      constructor() {
+        super()
+        resolve(this.attachShadow({ mode: 'open' }))
+      }
     }
-    constructor() {
-      super()
-      host = this.attachShadow({ mode: 'open' })
+    const hasDef = window.customElements.get(app.name)
+    if (!hasDef) {
+      customElements.define(app.name, Berial)
     }
-  }
-  const hasDef = window.customElements.get(app.name)
-  if (!hasDef) {
-    customElements.define(app.name, Berial)
-  }
-  return host
+  })
 }
 
 async function runUnmount(app: App): Promise<App> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export type App = {
   name: string
   url: ((props: App['props']) => Lifecycle) | string
   match: (location: Location) => boolean
-  host: HTMLElement
+  host: DocumentFragment
   props: Record<string, unknown>
   status: Status
   loaded?: any


### PR DESCRIPTION
在组件渲染之前获取shadowRoot，此时没有`<child-fre>`等自定义标签，导致host为空而报错