### PR TITLE
document mutation observer

### DIFF
--- a/src/html-loader.ts
+++ b/src/html-loader.ts
@@ -55,24 +55,24 @@ export async function importHtml(
   const template = await request(app.url as string)
   const styleNodes = await loadCSS(template)
   const bodyNode = loadBody(template)
-  const lifecycle = await loadScript(template, app.name)
+  const lifecycle = await loadScript(template, app)
   return { lifecycle, styleNodes, bodyNode }
 }
 
 export async function loadScript(
   template: string,
-  name: string
+  { name, host }: any
 ): Promise<Lifecycles> {
-  var bootstrap: PromiseFn[] = []
-  var unmount: PromiseFn[] = []
-  var mount: PromiseFn[] = []
-  var scriptsNextTick: string[] = []
+  let bootstrap: PromiseFn[] = []
+  let unmount: PromiseFn[] = []
+  let mount: PromiseFn[] = []
+  let scriptsNextTick: string[] = []
 
   new MutationObserver((mutations) => {
     mutations.forEach(async (m: any) => {
       switch (m.type) {
         case 'childList':
-          if (m.target !== 0) {
+          if (m.target !== host) {
             for (let i = 0; i < m.addedNodes.length; i++) {
               const node = m.addedNodes[i]
               if (node instanceof HTMLScriptElement) {
@@ -95,8 +95,8 @@ export async function loadScript(
     })
   )
 
-  function getLyfecycles(script: string) {
-    var lifecycles = run(script, {})[name]
+  function getLyfecycles(script: string): void {
+    let lifecycles = run(script, {})[name]
     if (lifecycles) {
       bootstrap =
         typeof lifecycles.bootstrap === 'function'

--- a/src/html-loader.ts
+++ b/src/html-loader.ts
@@ -1,7 +1,7 @@
 import type { App, PromiseFn, Lifecycles } from './types'
 
 import { run } from './sandbox'
-import { request } from './util'
+import { request, nextTick } from './util'
 
 const MATCH_ANY_OR_NO_PROPERTY = /["'=\w\s\/]*/
 const SCRIPT_URL_RE = new RegExp(
@@ -63,6 +63,31 @@ export async function loadScript(
   template: string,
   name: string
 ): Promise<Lifecycles> {
+  var bootstrap: PromiseFn[] = []
+  var unmount: PromiseFn[] = []
+  var mount: PromiseFn[] = []
+  var scriptsNextTick: string[] = []
+
+  new MutationObserver((mutations) => {
+    mutations.forEach(async (m: any) => {
+      switch (m.type) {
+        case 'childList':
+          if (m.target !== 0) {
+            for (let i = 0; i < m.addedNodes.length; i++) {
+              const node = m.addedNodes[i]
+              if (node instanceof HTMLScriptElement) {
+                const src = node.getAttribute('src') || ''
+                const script = await request(src)
+                scriptsNextTick.push(script)
+              }
+            }
+          }
+          break
+        default:
+      }
+    })
+  }).observe(document, { childList: true, subtree: true })
+
   const scriptsToLoad = await Promise.all(
     parseScript(template).map((v: string) => {
       if (TEST_URL.test(v)) return request(v)
@@ -70,11 +95,8 @@ export async function loadScript(
     })
   )
 
-  let bootstrap: PromiseFn[] = []
-  let unmount: PromiseFn[] = []
-  let mount: PromiseFn[] = []
-  scriptsToLoad.forEach((script) => {
-    const lifecycles = run(script, {})[name]
+  function getLyfecycles(script: string) {
+    var lifecycles = run(script, {})[name]
     if (lifecycles) {
       bootstrap =
         typeof lifecycles.bootstrap === 'function'
@@ -89,7 +111,10 @@ export async function loadScript(
           ? [...unmount, lifecycles.unmount]
           : unmount
     }
-  })
+  }
+
+  scriptsToLoad.forEach(getLyfecycles)
+  nextTick(() => scriptsNextTick.forEach(getLyfecycles))
 
   return { bootstrap, unmount, mount }
 }

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -137,7 +137,6 @@ export function run(code: string, options: any = {}): any {
   }
 }
 function checkSyntax(code: string): boolean {
-  Function(code)
   if (/\bimport\s*(?:[(]|\/[*]|\/\/|<!--|-->)/.test(code)) {
     throw new Error('Dynamic imports are blocked')
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -46,5 +46,5 @@ export function reverse<T>(arr: T[]): T[] {
 }
 
 export function nextTick(cb: () => void): void {
-  Promise.resolve().then(cb);
+  Promise.resolve().then(cb)
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -44,3 +44,7 @@ export function lifecycleCheck(lifecycle: Lifecycle | Lifecycles): void {
 export function reverse<T>(arr: T[]): T[] {
   return Array.from(arr).reverse()
 }
+
+export function nextTick(cb: () => void): void {
+  Promise.resolve().then(cb);
+}


### PR DESCRIPTION
这个 pr 是解决逃逸问题的，issue 在这里：https://github.com/berialjs/berial/issues/62

思路是使用 MutationObserver 对 document 进行观察，如果发现当前沙雕以外的 dom 发生了变化，则看看是不是 script 变化，如果是，则收集起来，在下一个 tick 批量塞到沙箱里跑

相比较 qiankun 的 Proxy 劫持的思路要靠谱得多